### PR TITLE
enhance: add arg for third party integration credentials

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -146,11 +146,11 @@ steps:
 The plugin accepts the following files for authentication:
 
 | Parameter  | Volume Configuration                                          |
-| ---------- | ------------------------------------------------------------- |
-| `password` | `/vela/parameters/npm/password`, `/vela/secrets/npm/password` |
-| `username` | `/vela/parameters/npm/username`, `/vela/secrets/npm/username` |
-| `registry` | `/vela/parameters/npm/registry`, `/vela/secrets/npm/registry` |
-| `email`    | `/vela/parameters/npm/email`, `/vela/secrets/npm/email`       |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| `password` | `/vela/parameters/npm/password`, `/vela/secrets/npm/password`, `/vela/secrets/managed-auth/password` |
+| `username` | `/vela/parameters/npm/username`, `/vela/secrets/npm/username`, `/vela/secrets/managed-auth/username` |
+| `registry` | `/vela/parameters/npm/registry`, `/vela/secrets/npm/registry`                                        |
+| `email`    | `/vela/parameters/npm/email`, `/vela/secrets/npm/email`                                              |
 
 Users can use [Vela external secrets](https://go-vela.github.io/docs/concepts/pipeline/secrets/origin/) to substitute these sensitive values at runtime:
 

--- a/cmd/vela-npm/main.go
+++ b/cmd/vela-npm/main.go
@@ -54,7 +54,7 @@ func main() {
 				Aliases:     []string{"u"},
 				Usage:       "name of user",
 				EnvVars:     []string{"PARAMETER_USERNAME", "PLUGIN_USERNAME", "NPM_USERNAME"},
-				FilePath:    string("/vela/parameters/npm/username,/vela/secrets/npm/username,/vela/secrets/auth/username"),
+				FilePath:    string("/vela/parameters/npm/username,/vela/secrets/npm/username,/vela/secrets/managed-auth/username"),
 				DefaultText: "N/A",
 			},
 			&cli.StringFlag{
@@ -62,7 +62,7 @@ func main() {
 				Aliases:     []string{"p"},
 				Usage:       "password for user",
 				EnvVars:     []string{"PARAMETER_PASSWORD", "PLUGIN_PASSWORD", "NPM_PASSWORD"},
-				FilePath:    string("/vela/parameters/npm/password,/vela/secrets/npm/password,/vela/secrets/auth/password"),
+				FilePath:    string("/vela/parameters/npm/password,/vela/secrets/npm/password,/vela/secrets/managed-auth/password"),
 				DefaultText: "N/A",
 			},
 			&cli.StringFlag{

--- a/cmd/vela-npm/main.go
+++ b/cmd/vela-npm/main.go
@@ -54,7 +54,7 @@ func main() {
 				Aliases:     []string{"u"},
 				Usage:       "name of user",
 				EnvVars:     []string{"PARAMETER_USERNAME", "PLUGIN_USERNAME", "NPM_USERNAME"},
-				FilePath:    string("/vela/parameters/npm/username,/vela/secrets/npm/username"),
+				FilePath:    string("/vela/parameters/npm/username,/vela/secrets/npm/username,/vela/secrets/auth/username"),
 				DefaultText: "N/A",
 			},
 			&cli.StringFlag{
@@ -62,7 +62,7 @@ func main() {
 				Aliases:     []string{"p"},
 				Usage:       "password for user",
 				EnvVars:     []string{"PARAMETER_PASSWORD", "PLUGIN_PASSWORD", "NPM_PASSWORD"},
-				FilePath:    string("/vela/parameters/npm/password,/vela/secrets/npm/password"),
+				FilePath:    string("/vela/parameters/npm/password,/vela/secrets/npm/password,/vela/secrets/auth/password"),
 				DefaultText: "N/A",
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
support for a third-party integration that writes shared credentials to the managed-auth filepath.
